### PR TITLE
Add area-web build job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,29 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  build_web:
+    name: Build (area-web)
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
+      (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'dev'))
+    defaults:
+      run:
+        working-directory: area-web
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: area-web/package.json
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
This pull request introduces a new build job for the `area-web` application in the GitHub Actions workflow. The job is configured to trigger on push or pull request events targeting the `main` and `dev` branches.