### PR TITLE
Add mobile build job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,37 @@ jobs:
       - name: Build
         run: npm run build
 
+  build_mobile:
+    name: Build (area-mobile)
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
+      (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'dev'))
+    defaults:
+      run:
+        working-directory: area-mobile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: area-mobile/package.json
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Validate project with Expo Doctor
+        run: npx expo doctor
+
+      - name: Build (Expo export for web)
+        env:
+          CI: true
+        run: npx expo export --platform web --output-dir dist-web
+
   build_web:
     name: Build (area-web)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enhancements:

- Introduced a new `build_mobile` job within the CI workflow.
- Configured it to handle mobile project builds for `main` and `dev` branches upon push and pull request events.
- Includes dependency installation, validation, and Expo web export.