### PR TITLE
Implement Spotify API helper with token auto-refresh

### DIFF
--- a/area-backend/src/modules/actions/spotify/like.service.ts
+++ b/area-backend/src/modules/actions/spotify/like.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { UsersService } from 'src/modules/users/users.service';
 import { AuthService } from 'src/modules/auth/auth.service';
 import { RedisService } from 'src/modules/redis/redis.service';
-import axios from 'axios';
 
 @Injectable()
 export class SpotifyLikeService {
@@ -33,14 +32,14 @@ export class SpotifyLikeService {
       return -1; // No Spotify token
     }
 
-    // Poll Spotify API for the most recent liked track
-    const response = await axios.get('https://api.spotify.com/v1/me/tracks?limit=1', {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+    // Poll Spotify API for the most recent liked track using auto-refresh helper
+    const { data } = await this.authService.spotifyApiRequest<any>(userId, {
+      url: 'https://api.spotify.com/v1/me/tracks',
+      method: 'GET',
+      params: { limit: 1 },
     });
 
-    const items = response.data.items;
+    const items = data.items;
     if (!items || items.length === 0) {
       // No likes at all
     await this.redisService.setValue(cacheKey, '');

--- a/area-backend/src/modules/auth/auth.service.ts
+++ b/area-backend/src/modules/auth/auth.service.ts
@@ -14,6 +14,7 @@ import {JwtService} from '@nestjs/jwt';
 import {ConfigService} from '@nestjs/config';
 import {google} from 'googleapis';
 import * as crypto from 'crypto';
+import axios, { AxiosRequestConfig } from 'axios';
 
 
 @Injectable()
@@ -629,10 +630,61 @@ export class AuthService {
                 accessTokenExpiresAt: new Date(Date.now() + expiresIn * 1000),
             });
 
+            this.logger.log(`Refreshed Spotify access token for user ${userId}`);
+
             return {spotifyAccessToken: newAccessToken, expiresIn};
         } catch (e: any) {
             this.logger.error(`Failed to refresh Spotify access token: ${e?.message ?? e}`, e?.stack);
             throw new UnauthorizedException('Failed to refresh Spotify token');
+        }
+    }
+
+    /**
+     * Returns the current decrypted Spotify access token for a user or throws if missing.
+     */
+    async getCurrentSpotifyAccessToken(userId: string): Promise<string> {
+        const account = await this.usersService.findUserOAuthAccount(userId, 'spotify');
+        if (!account || !account.access_token) {
+            throw new BadRequestException('No Spotify access token stored');
+        }
+        const token = this.decrypt(account.access_token);
+        if (!token) {
+            throw new BadRequestException('Invalid Spotify access token');
+        }
+        return token;
+    }
+
+    /**
+     * Perform a Spotify API request with automatic token refresh and single retry on 401.
+     * - Uses user's current access token
+     * - On 401, refreshes using stored refresh_token, updates DB, and retries once
+     */
+    async spotifyApiRequest<T = any>(userId: string, config: AxiosRequestConfig): Promise<{ data: T; status: number }> {
+        if (!userId) throw new BadRequestException('Missing userId');
+
+        const doRequest = async (bearer: string) => {
+            const headers = {
+                ...(config.headers || {}),
+                Authorization: `Bearer ${bearer}`,
+            } as Record<string, string>;
+            return axios.request<T>({ ...config, headers });
+        };
+
+        let accessToken = await this.getCurrentSpotifyAccessToken(userId);
+        try {
+            const res = await doRequest(accessToken);
+            return { data: res.data, status: res.status };
+        } catch (err: any) {
+            const status = err?.response?.status;
+            // Only attempt refresh on 401 Unauthorized
+            if (status !== 401) {
+                throw err;
+            }
+            // Refresh token, update DB, and retry once
+            const refreshed = await this.refreshSpotifyAccessToken(userId);
+            accessToken = refreshed.spotifyAccessToken;
+            const res2 = await doRequest(accessToken);
+            return { data: res2.data, status: res2.status };
         }
     }
 }


### PR DESCRIPTION
# Description
Added a helper method for making Spotify API requests with automatic token refresh and retry on receiving a 401 response. Simplifies token management in SpotifyLikeService by using the new helper.

# Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

# Tests
List of tests performed and instructions to reproduce if needed.

**Example:**
- [ ] Unit tests
- [ ] Integration tests

# Checklist
- [ ] Code follows project standards
- [ ] Self-review completed
- [ ] Documentation updated if necessary
- [ ] Unit tests passed
- [ ] Dependencies merged and published