### PR TITLE
refactor: proper separation from types and services

### DIFF
--- a/area-backend/src/modules/actions/spotify/like.service.ts
+++ b/area-backend/src/modules/actions/spotify/like.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ProviderKey, UsersService } from '../../users/users.service';
 import { AuthService } from '../../auth/auth.service';
 import { RedisService } from '../../redis/redis.service';
-import type { PollingAction } from '../polling/ActionPollingService';
+import type { PollingAction } from '../../actions/types/ActionPollingType';
 
 /**
  * Spotify polling action that detects if the user has liked a new track.

--- a/area-backend/src/modules/actions/types/ActionPollingType.ts
+++ b/area-backend/src/modules/actions/types/ActionPollingType.ts
@@ -1,0 +1,13 @@
+/**
+ * Interface for an action that can be polled periodically.
+ * Implementations decide if they support a given action name and handle
+ * starting/stopping polling per user.
+ */
+export interface PollingAction {
+  /** Returns true if this poller supports the specified action name. */
+  supports(actionName: string): boolean;
+  /** Starts polling for a given user and emits a numeric result to the callback. */
+  start(userId: string, emit: (result: number) => void): void;
+  /** Stops polling for a given user. */
+  stop(userId: string): void;
+}

--- a/area-backend/src/modules/manager/manager.module.ts
+++ b/area-backend/src/modules/manager/manager.module.ts
@@ -7,7 +7,7 @@ import { RedisModule } from '../redis/redis.module';
 import { SpotifyLikeService } from '../actions/spotify/like.service';
 import { UsersModule } from '../users/users.module';
 import { AuthModule } from '../auth/auth.module';
-import { ActionPollingService } from '../actions/polling/ActionPollingService';
+import { ActionPollingService } from './polling/ActionPollingService';
 
 /**
  * Manager module orchestrating AREA logic (Actions <-> Reactions).

--- a/area-backend/src/modules/manager/manager.service.ts
+++ b/area-backend/src/modules/manager/manager.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy, BadRequestException, NotFoundException } from '@nestjs/common';
 import { SpotifyLikeService } from '../actions/spotify/like.service';
-import { ActionPollingService } from '../actions/polling/ActionPollingService';
+import { ActionPollingService } from './polling/ActionPollingService';
 import { PrismaService } from '../../prisma/prisma.service';
 import { RedisService } from '../redis/redis.service';
 

--- a/area-backend/src/modules/manager/polling/ActionPollingService.ts
+++ b/area-backend/src/modules/manager/polling/ActionPollingService.ts
@@ -1,18 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-
-/**
- * Interface for an action that can be polled periodically.
- * Implementations decide if they support a given action name and handle
- * starting/stopping polling per user.
- */
-export interface PollingAction {
-  /** Returns true if this poller supports the specified action name. */
-  supports(actionName: string): boolean;
-  /** Starts polling for a given user and emits a numeric result to the callback. */
-  start(userId: string, emit: (result: number) => void): void;
-  /** Stops polling for a given user. */
-  stop(userId: string): void;
-}
+import type { PollingAction } from '../../actions/types/ActionPollingType';
 
 /**
  * Registry and coordinator for `PollingAction` implementations.


### PR DESCRIPTION
# Description
This pull request refactors the location and usage of the `PollingAction` interface to improve code organization and maintainability. The interface is moved to a dedicated types file, and related imports are updated across the codebase. Additionally, the `ActionPollingService` is relocated from the actions module to the manager module, with corresponding import path updates.

**Refactoring and code organization:**

* Moved the `PollingAction` interface from `area-backend/src/modules/actions/polling/ActionPollingService.ts` to a new dedicated types file `area-backend/src/modules/actions/types/ActionPollingType.ts`, and updated all relevant imports to reference the new location. [[1]](diffhunk://#diff-01af4444daf2ff219bb0c6d2043003bf5be06955d77ae1d6d7f262665852cb5eR1-R13) [[2]](diffhunk://#diff-8fd5330f7808206a7d43f274e2c1872f7313e9ec66e94f914c498378d52d9b8fL5-R5) [[3]](diffhunk://#diff-c4be20bdc47054320856715a8be98e1668a12a5e223f12c8d9ebb3d0ecf7e34cL2-R2)
* Relocated `ActionPollingService` from `area-backend/src/modules/actions/polling/ActionPollingService.ts` to `area-backend/src/modules/manager/polling/ActionPollingService.ts`, and updated import paths in `manager.module.ts` and `manager.service.ts` accordingly. [[1]](diffhunk://#diff-c4be20bdc47054320856715a8be98e1668a12a5e223f12c8d9ebb3d0ecf7e34cL2-R2) [[2]](diffhunk://#diff-348dbc7c5a91d0cbdd776eb55f86091384d58854d2f362a3274bb45955504d6eL10-R10) [[3]](diffhunk://#diff-4cd0404c99483ed0f637df84c5c46f5c1f5a33d5806834ffb4328bd444afd77eL3-R3)

# Type of change
- [ ] Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Other (please specify)
