### PR TITLE
fix: Users delete erroring because of improper deletion

### DIFF
--- a/area-backend/src/modules/users/users.service.ts
+++ b/area-backend/src/modules/users/users.service.ts
@@ -115,8 +115,10 @@ export class UsersService {
             if (!user) {
                 throw new NotFoundException('User not found');
             }
+            await tx.event_logs.deleteMany({ where: { user_id: id } });
             await tx.auth_identities.deleteMany({ where: { user_id: id } });
             await tx.linked_accounts.deleteMany({ where: { user_id: id } });
+            await tx.areas.deleteMany({ where: { user_id: id } });
             return tx.users.delete({ where: { id } });
         });
     }


### PR DESCRIPTION
## Description
This pull request improves the user deletion logic by ensuring that all related data is properly cleaned up when a user is deleted. In addition to deleting authentication identities and linked accounts, it now also deletes the user's event logs and areas.

Data cleanup enhancements:

* When deleting a user, the service now also deletes all associated records in the `event_logs` table to prevent orphaned data.
* The service now deletes all associated records in the `areas` table during user deletion for more thorough cleanup.

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify)