### PR TITLE
Add Notion OAuth integration and documentation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,6 +37,10 @@ SLACK_CLIENT_ID=""
 SLACK_CLIENT_SECRET=""
 SLACK_REDIRECT_URI="http://localhost:3000/auth/slack/callback"
 
+NOTION_CLIENT_ID=""
+NOTION_CLIENT_SECRET=""
+NOTION_REDIRECT_URI="http://localhost:3000/auth/notion/callback"
+
 # Symmetric secret used to encrypt OAuth access/refresh tokens
 # AES-256-GCM key is derived as SHA-256(TOKENS_ENC_KEY). Keep this value stable.
 # Changing it will invalidate the ability to decrypt previously stored tokens.

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -24,6 +24,7 @@ import { GoogleLinking } from './plugins/google/google-linking';
 import { SpotifyLinking } from './plugins/spotify/spotify-linking';
 import { DiscordLinking } from './plugins/discord/discord-linking';
 import { SlackLinking } from './plugins/slack/slack-linking';
+import { NotionLinking } from './plugins/notion/notion-linking';
 
 /**
  * Authentication service handling email/password flows, verification,
@@ -60,6 +61,7 @@ export class AuthService {
             reg.addLinking(new SpotifyLinking(this.config, this.jwtService, this.tokenStore, this.cryptoSvc, this.http));
             reg.addLinking(new DiscordLinking(this.config, this.jwtService, this.tokenStore, this.cryptoSvc, this.http));
             reg.addLinking(new SlackLinking(this.config, this.jwtService, this.tokenStore, this.cryptoSvc, this.http));
+            reg.addLinking(new NotionLinking(this.config, this.jwtService, this.tokenStore, this.cryptoSvc, this.http));
             (this as any)._providers = reg;
         }
         return (this as any)._providers as ProviderRegistryImpl;

--- a/backend/src/modules/auth/plugins/notion/README.md
+++ b/backend/src/modules/auth/plugins/notion/README.md
@@ -1,377 +1,53 @@
-# Notion OAuth Integration
+# Notion OAuth — Quick Setup
 
-Ce guide explique comment configurer l'authentification Notion pour une application IFTTT-like.
+Minimal steps to create and use a Notion integration with this project.
 
-## Architecture Notion pour IFTTT
+## 1) Create the integration
+- Go to https://www.notion.so/my-integrations → + New integration
+- Name it, select your workspace, Save
 
-**Cette implémentation utilise un Bot Token (workspace-level)** :
+## 2) Grab credentials
+- OAuth client ID → NOTION_CLIENT_ID
+- OAuth client secret → NOTION_CLIENT_SECRET
 
-### Bot Token (workspace-level)
-- 🎯 **Usage**: ACTIONS et REACTIONS - Lire et écrire dans Notion
-- ✅ Accès aux pages partagées avec l'intégration
-- ✅ Ne expire jamais
-- ✅ Idéal pour créer des pages, databases, et lire du contenu
-- 📍 Token `secret_...`
+## 3) Redirect URI (must match exactly)
+Add one or more Redirect URIs in “Distribution”:
+- Dev: http://localhost:3000/auth/notion/callback
+- Ngrok: https://<subdomain>.ngrok-free.app/auth/notion/callback
+- Prod: https://your-domain.com/auth/notion/callback
 
-### Exemple de workflow IFTTT
+## 4) Capabilities (minimum)
+Enable in the integration settings:
+- Content: Read content, Insert content, Update content
+- User: Read user information without email (optional)
+
+## 5) Share your pages/databases
+For the integration to access resources, you must share them with the integration in Notion:
+Page → … menu → Add connections → select your integration.
+
+## 6) Environment variables
+Add to backend .env:
 ```
-IF: Nouveau email reçu (Gmail)
-THEN: Crée une page dans Notion avec le contenu de l'email
-
-IF: Nouvelle tâche dans une database Notion
-THEN: Envoie une notification Slack
-```
-
-## Table des matières
-
-1. [Création de l'intégration Notion](#création-de-lintégration-notion)
-2. [Configuration OAuth](#configuration-oauth)
-3. [Variables d'environnement](#variables-denvironnement)
-4. [Capacités disponibles](#capacités-disponibles)
-5. [Test de l'intégration](#test-de-lintégration)
-
----
-
-## Création de l'intégration Notion
-
-### 1. Créer une intégration Notion
-
-1. Accédez à [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
-2. Cliquez sur **"+ New integration"**
-3. Donnez un nom à votre intégration (ex: "AREA Bot")
-4. Sélectionnez le workspace associé
-5. Configurez les capacités (voir section ci-dessous)
-6. Cliquez sur **"Submit"**
-
-### 2. Récupérer les credentials
-
-Dans la page de votre intégration :
-
-1. **Onglet "Secrets"** :
-   - Notez le **OAuth client ID** → Utilisez-le pour `NOTION_CLIENT_ID`
-   - Notez le **OAuth client secret** → Utilisez-le pour `NOTION_CLIENT_SECRET`
-
-2. **Onglet "Distribution"** (pour OAuth public) :
-   - Activez **"Public integration"** si vous voulez que d'autres utilisateurs puissent s'y connecter
-   - Sinon, restez en mode "Internal integration" pour tester
-
-Ces credentials sont nécessaires pour l'intégration OAuth.
-
----
-
-## Configuration OAuth
-
-### 1. Configurer les Redirect URLs
-
-Dans l'onglet **"Distribution"** > **"Redirect URIs"**:
-
-1. Cliquez sur **"Add redirect URI"**
-2. Ajoutez votre URL de callback selon votre environnement:
-
-   **Pour le développement local**:
-   ```
-   http://localhost:3000/auth/notion/callback
-   ```
-
-   **Pour le développement avec ngrok** (recommandé pour tester):
-   ```
-   https://your-subdomain.ngrok-free.app/auth/notion/callback
-   ```
-
-   **Pour la production**:
-   ```
-   https://votre-domaine.com/auth/notion/callback
-   ```
-
-3. Cliquez sur **"Add URI"**
-
-💡 **Astuce ngrok**: Pour tester OAuth en développement, utilisez ngrok pour exposer votre backend local :
-```bash
-ngrok http 3000
-```
-Puis utilisez l'URL HTTPS fournie comme redirect URI.
-
-### 2. Configurer les Capabilities
-
-Dans l'onglet **"Capabilities"**, activez les permissions dont vous avez besoin :
-
-#### Content Capabilities (Contenu)
-- ✅ **Read content** - Lire les pages et databases
-- ✅ **Update content** - Modifier le contenu existant
-- ✅ **Insert content** - Créer de nouvelles pages et blocs
-
-#### User Capabilities (Utilisateurs)
-- ✅ **Read user information without email** - Lire les infos basiques des utilisateurs
-- ⬜ **Read user information with email** - Lire les emails (optionnel)
-
-#### Comment Capabilities (Commentaires)
-- ⬜ **Read comments** - Lire les commentaires (optionnel)
-- ⬜ **Create comments** - Créer des commentaires (optionnel)
-
-**Note**: Contrairement à d'autres OAuth providers, Notion n'utilise pas de "scopes" dans l'URL d'autorisation. Les permissions sont configurées au niveau de l'intégration et l'utilisateur accepte toutes les permissions lors de la connexion.
-
-### 3. Distribution (Rendre l'intégration publique)
-
-Si vous voulez que n'importe quel utilisateur Notion puisse connecter votre app :
-
-1. Allez dans **"Distribution"**
-2. Activez **"Make integration public"**
-3. Remplissez les informations requises :
-   - Description de l'intégration
-   - Logo (optionnel)
-   - Lien vers la politique de confidentialité
-   - Lien vers les conditions d'utilisation
-4. Soumettez pour révision si nécessaire
-
-⚠️ **Pour le développement**, restez en mode "Internal" jusqu'à ce que tout fonctionne.
-
----
-
-## Variables d'environnement
-
-Ajoutez les variables suivantes à votre fichier `.env`:
-
-```env
-# Notion OAuth Configuration
-NOTION_CLIENT_ID=your_client_id_here
-NOTION_CLIENT_SECRET=your_client_secret_here
+NOTION_CLIENT_ID=...
+NOTION_CLIENT_SECRET=...
 NOTION_REDIRECT_URI=http://localhost:3000/auth/notion/callback
 ```
-
-### Configuration selon l'environnement
-
-**Développement local** (port par défaut 3000):
-```env
-NOTION_REDIRECT_URI=http://localhost:3000/auth/notion/callback
-```
-
-**Développement avec ngrok** (pour tester avec Notion):
-```env
-NOTION_REDIRECT_URI=https://your-subdomain.ngrok-free.app/auth/notion/callback
-```
-
-**Production**:
-```env
-NOTION_REDIRECT_URI=https://votre-domaine.com/auth/notion/callback
-```
-
-⚠️ **Important**: La `NOTION_REDIRECT_URI` doit **exactement** correspondre à celle configurée dans votre intégration Notion (section "Distribution" > "Redirect URIs").
-
----
-
-## Capacités disponibles
-
-### Opérations sur les pages
-
-| Opération              | Description                                       |
-|------------------------|---------------------------------------------------|
-| Lire une page          | Récupérer le contenu et les propriétés d'une page |
-| Créer une page         | Créer une nouvelle page dans Notion               |
-| Mettre à jour une page | Modifier les propriétés d'une page existante      |
-| Archiver une page      | Archiver une page                                 |
-
-### Opérations sur les databases
-
-| Opération                | Description                                             |
-|--------------------------|---------------------------------------------------------|
-| Lire une database        | Récupérer les propriétés et la structure d'une database |
-| Requêter une database    | Rechercher et filtrer des entrées dans une database     |
-| Créer une entrée         | Ajouter une nouvelle ligne dans une database            |
-| Mettre à jour une entrée | Modifier une entrée existante                           |
-
-### Opérations sur les blocs
-
-| Opération              | Description                                      |
-|------------------------|--------------------------------------------------|
-| Lire les blocs enfants | Récupérer les blocs de contenu d'une page        |
-| Ajouter des blocs      | Insérer du nouveau contenu (texte, images, etc.) |
-| Mettre à jour un bloc  | Modifier un bloc existant                        |
-| Supprimer un bloc      | Supprimer un bloc                                |
-
-### Opérations sur les utilisateurs
-
-| Opération               | Description                                    |
-|-------------------------|------------------------------------------------|
-| Lire un utilisateur     | Récupérer les infos d'un utilisateur           |
-| Lister les utilisateurs | Obtenir la liste des utilisateurs du workspace |
-
----
-
-## Spécificités de l'API Notion
-
-### Version de l'API
-
-Notion utilise un système de versioning par date. Ajoutez toujours le header suivant dans vos requêtes :
-
-```
-Notion-Version: 2022-06-28
-```
-
-### Format d'authentification
-
-L'authentification OAuth de Notion utilise :
-- **Basic Auth** pour l'échange du code (format `clientId:clientSecret` en base64)
-- **Bearer Token** pour les requêtes API (`Authorization: Bearer <access_token>`)
-
-### Tokens qui n'expirent pas
-
-**Particularité importante** : Les access tokens Notion n'expirent jamais et il n'y a pas de refresh token. Une fois obtenu, le token reste valide jusqu'à ce que :
-- L'utilisateur révoque l'accès manuellement
-- L'intégration soit supprimée
-- L'intégration soit retirée du workspace
-
-### Partage des pages
-
-Pour qu'une intégration puisse accéder à une page ou database Notion, **l'utilisateur doit explicitement partager la page avec l'intégration**. Cela se fait via :
-1. Le menu "..." en haut à droite d'une page
-2. "Add connections"
-3. Sélectionner votre intégration
-
-Sans ce partage, l'API retournera une erreur 404 même si le token est valide.
-
----
-
-## Test de l'intégration
-
-### 1. Démarrer le backend
-
-```bash
-cd backend
-npm run start:dev
-```
-
-### 2. Tester la connexion
-
-**Via l'interface frontend** :
-1. Accédez à la page de connexion
-2. Cliquez sur "Connect with Notion"
-3. Autorisez l'accès dans Notion
-4. Vous serez redirigé vers votre application
-
-**Via API directe** :
-```bash
-# 1. Obtenir l'URL de consentement
-curl http://localhost:3000/auth/notion/link?userId=your-user-id
-
-# 2. Ouvrir l'URL dans un navigateur et autoriser
-# 3. Le callback sera traité automatiquement
-```
-
-### 3. Vérifier le lien
-
-**Via l'API** :
-```bash
-# Vérifier que le compte est bien lié
-curl -H "Authorization: Bearer <your-jwt>" \
-  http://localhost:3000/auth/linked-accounts
-```
-
-**Dans la base de données** :
-```sql
-SELECT * FROM linked_accounts WHERE provider = 'notion' AND user_id = 'your-user-id';
-```
-
-### 4. Tester une requête API Notion
-
-Une fois lié, testez une requête simple :
-
-```typescript
-// Exemple : Lister les pages accessibles
-const accessToken = await notionLinking.getCurrentAccessToken(userId);
-
-const response = await fetch('https://api.notion.com/v1/search', {
-  method: 'POST',
-  headers: {
-    'Authorization': `Bearer ${accessToken}`,
-    'Notion-Version': '2022-06-28',
-    'Content-Type': 'application/json',
-  },
-  body: JSON.stringify({
-    filter: { property: 'object', value: 'page' }
-  })
-});
-
-const data = await response.json();
-console.log('Pages accessibles:', data.results);
-```
-
----
-
-## Débogage
-
-### Erreur : "Invalid client_id or redirect_uri"
-
-**Cause** : Le client ID ou le redirect URI ne correspond pas à la configuration de votre intégration.
-
-**Solution** :
-1. Vérifiez que `NOTION_CLIENT_ID` correspond bien au OAuth client ID de votre intégration
-2. Vérifiez que `NOTION_REDIRECT_URI` est exactement le même que celui configuré dans "Distribution" > "Redirect URIs"
-3. Attention aux trailing slashes et au protocole (http vs https)
-
-### Erreur : "Unauthorized" ou 401
-
-**Cause** : Le token n'est pas valide ou a été révoqué.
-
-**Solution** :
-1. Vérifiez que le token est bien stocké et chiffré correctement
-2. Demandez à l'utilisateur de se reconnecter
-3. Vérifiez que l'intégration n'a pas été retirée du workspace
-
-### Erreur : "Object not found" ou 404
-
-**Causes possibles** :
-1. La page/database n'existe pas
-2. **L'intégration n'a pas accès à cette page** (cause la plus fréquente)
-
-**Solution** :
-1. Vérifiez que la page est bien partagée avec votre intégration
-2. Dans Notion, ouvrez la page → "..." → "Add connections" → Sélectionnez votre intégration
-3. Testez avec une page de test que vous avez explicitement partagée
-
-### Le token ne fonctionne plus
-
-**Cause** : L'utilisateur a révoqué l'accès ou l'intégration a été retirée.
-
-**Solution** :
-1. Vérifiez dans [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
-2. Demandez à l'utilisateur de se reconnecter
-3. Implémentez une gestion d'erreur qui détecte les 401 et demande une reconnexion
-
----
-
-## Ressources officielles
-
-- 📖 [Documentation officielle Notion API](https://developers.notion.com/)
-- 🔐 [Guide OAuth Notion](https://developers.notion.com/docs/authorization)
-- 🎯 [Référence API complète](https://developers.notion.com/reference/intro)
-- 💬 [Forum développeurs Notion](https://community.notion.so/)
-- 🛠️ [SDK JavaScript officiel](https://github.com/makenotion/notion-sdk-js)
-
----
-
-## Notes pour les développeurs
-
-### Différences avec d'autres OAuth providers
-
-1. **Pas de scopes** : Les permissions sont définies au niveau de l'intégration, pas dans l'URL OAuth
-2. **Basic Auth** : L'échange de code utilise Basic Auth au lieu de form-urlencoded
-3. **Tokens permanents** : Pas d'expiration, pas de refresh token
-4. **Partage explicite** : Les utilisateurs doivent manuellement partager chaque page avec l'intégration
-5. **API versionnée par date** : Toujours inclure le header `Notion-Version`
-
-### Bonnes pratiques
-
-1. **Gestion d'erreurs robuste** : Toujours vérifier les 401/404 et guider l'utilisateur
-2. **Rate limiting** : Notion limite à 3 requêtes par seconde (respectez les headers `Retry-After`)
-3. **Pagination** : Utilisez le paramètre `start_cursor` pour les listes longues
-4. **Cache** : Les tokens ne changeant jamais, vous pouvez les cacher longtemps
-5. **Validation** : Testez régulièrement que les tokens fonctionnent encore
-
-### Sécurité
-
-- ✅ Les tokens sont chiffrés avant d'être stockés en base de données
-- ✅ Le state JWT expire après 10 minutes pour éviter les attaques CSRF
-- ✅ Utilisez toujours HTTPS en production
-- ✅ Ne loggez jamais les access tokens en clair
-- ✅ Implémentez un système de révocation des tokens si nécessaire
-
+Ensure NOTION_REDIRECT_URI exactly matches one of your Redirect URIs in Notion.
+
+## 7) Test the link flow
+- Start the backend
+- Open consent URL and connect your Notion:
+  - GET /auth/notion/link?userId=<your-user-id>
+- After consent, you’re redirected to /auth/notion/callback and the token is stored.
+
+## 8) Quick API notes
+- Headers: Authorization: Bearer <access_token>, Notion-Version: 2022-06-28
+- Tokens don’t expire (until revoked)
+- Rate limit ≈ 3 req/s
+
+## 9) Debug quick refs
+- 401 Unauthorized: token revoked → reconnect user
+- 404 Object not found: page/db not shared with integration → Share it (Add connections)
+- invalid_client / redirect_uri_mismatch: exact match required (protocol, host, path)
+
+That’s it. If the link works, you can list databases via the backend Notion endpoints and start using actions/reactions.

--- a/backend/src/modules/auth/plugins/notion/README.md
+++ b/backend/src/modules/auth/plugins/notion/README.md
@@ -1,0 +1,377 @@
+# Notion OAuth Integration
+
+Ce guide explique comment configurer l'authentification Notion pour une application IFTTT-like.
+
+## Architecture Notion pour IFTTT
+
+**Cette implémentation utilise un Bot Token (workspace-level)** :
+
+### Bot Token (workspace-level)
+- 🎯 **Usage**: ACTIONS et REACTIONS - Lire et écrire dans Notion
+- ✅ Accès aux pages partagées avec l'intégration
+- ✅ Ne expire jamais
+- ✅ Idéal pour créer des pages, databases, et lire du contenu
+- 📍 Token `secret_...`
+
+### Exemple de workflow IFTTT
+```
+IF: Nouveau email reçu (Gmail)
+THEN: Crée une page dans Notion avec le contenu de l'email
+
+IF: Nouvelle tâche dans une database Notion
+THEN: Envoie une notification Slack
+```
+
+## Table des matières
+
+1. [Création de l'intégration Notion](#création-de-lintégration-notion)
+2. [Configuration OAuth](#configuration-oauth)
+3. [Variables d'environnement](#variables-denvironnement)
+4. [Capacités disponibles](#capacités-disponibles)
+5. [Test de l'intégration](#test-de-lintégration)
+
+---
+
+## Création de l'intégration Notion
+
+### 1. Créer une intégration Notion
+
+1. Accédez à [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
+2. Cliquez sur **"+ New integration"**
+3. Donnez un nom à votre intégration (ex: "AREA Bot")
+4. Sélectionnez le workspace associé
+5. Configurez les capacités (voir section ci-dessous)
+6. Cliquez sur **"Submit"**
+
+### 2. Récupérer les credentials
+
+Dans la page de votre intégration :
+
+1. **Onglet "Secrets"** :
+   - Notez le **OAuth client ID** → Utilisez-le pour `NOTION_CLIENT_ID`
+   - Notez le **OAuth client secret** → Utilisez-le pour `NOTION_CLIENT_SECRET`
+
+2. **Onglet "Distribution"** (pour OAuth public) :
+   - Activez **"Public integration"** si vous voulez que d'autres utilisateurs puissent s'y connecter
+   - Sinon, restez en mode "Internal integration" pour tester
+
+Ces credentials sont nécessaires pour l'intégration OAuth.
+
+---
+
+## Configuration OAuth
+
+### 1. Configurer les Redirect URLs
+
+Dans l'onglet **"Distribution"** > **"Redirect URIs"**:
+
+1. Cliquez sur **"Add redirect URI"**
+2. Ajoutez votre URL de callback selon votre environnement:
+
+   **Pour le développement local**:
+   ```
+   http://localhost:3000/auth/notion/callback
+   ```
+
+   **Pour le développement avec ngrok** (recommandé pour tester):
+   ```
+   https://your-subdomain.ngrok-free.app/auth/notion/callback
+   ```
+
+   **Pour la production**:
+   ```
+   https://votre-domaine.com/auth/notion/callback
+   ```
+
+3. Cliquez sur **"Add URI"**
+
+💡 **Astuce ngrok**: Pour tester OAuth en développement, utilisez ngrok pour exposer votre backend local :
+```bash
+ngrok http 3000
+```
+Puis utilisez l'URL HTTPS fournie comme redirect URI.
+
+### 2. Configurer les Capabilities
+
+Dans l'onglet **"Capabilities"**, activez les permissions dont vous avez besoin :
+
+#### Content Capabilities (Contenu)
+- ✅ **Read content** - Lire les pages et databases
+- ✅ **Update content** - Modifier le contenu existant
+- ✅ **Insert content** - Créer de nouvelles pages et blocs
+
+#### User Capabilities (Utilisateurs)
+- ✅ **Read user information without email** - Lire les infos basiques des utilisateurs
+- ⬜ **Read user information with email** - Lire les emails (optionnel)
+
+#### Comment Capabilities (Commentaires)
+- ⬜ **Read comments** - Lire les commentaires (optionnel)
+- ⬜ **Create comments** - Créer des commentaires (optionnel)
+
+**Note**: Contrairement à d'autres OAuth providers, Notion n'utilise pas de "scopes" dans l'URL d'autorisation. Les permissions sont configurées au niveau de l'intégration et l'utilisateur accepte toutes les permissions lors de la connexion.
+
+### 3. Distribution (Rendre l'intégration publique)
+
+Si vous voulez que n'importe quel utilisateur Notion puisse connecter votre app :
+
+1. Allez dans **"Distribution"**
+2. Activez **"Make integration public"**
+3. Remplissez les informations requises :
+   - Description de l'intégration
+   - Logo (optionnel)
+   - Lien vers la politique de confidentialité
+   - Lien vers les conditions d'utilisation
+4. Soumettez pour révision si nécessaire
+
+⚠️ **Pour le développement**, restez en mode "Internal" jusqu'à ce que tout fonctionne.
+
+---
+
+## Variables d'environnement
+
+Ajoutez les variables suivantes à votre fichier `.env`:
+
+```env
+# Notion OAuth Configuration
+NOTION_CLIENT_ID=your_client_id_here
+NOTION_CLIENT_SECRET=your_client_secret_here
+NOTION_REDIRECT_URI=http://localhost:3000/auth/notion/callback
+```
+
+### Configuration selon l'environnement
+
+**Développement local** (port par défaut 3000):
+```env
+NOTION_REDIRECT_URI=http://localhost:3000/auth/notion/callback
+```
+
+**Développement avec ngrok** (pour tester avec Notion):
+```env
+NOTION_REDIRECT_URI=https://your-subdomain.ngrok-free.app/auth/notion/callback
+```
+
+**Production**:
+```env
+NOTION_REDIRECT_URI=https://votre-domaine.com/auth/notion/callback
+```
+
+⚠️ **Important**: La `NOTION_REDIRECT_URI` doit **exactement** correspondre à celle configurée dans votre intégration Notion (section "Distribution" > "Redirect URIs").
+
+---
+
+## Capacités disponibles
+
+### Opérations sur les pages
+
+| Opération              | Description                                       |
+|------------------------|---------------------------------------------------|
+| Lire une page          | Récupérer le contenu et les propriétés d'une page |
+| Créer une page         | Créer une nouvelle page dans Notion               |
+| Mettre à jour une page | Modifier les propriétés d'une page existante      |
+| Archiver une page      | Archiver une page                                 |
+
+### Opérations sur les databases
+
+| Opération                | Description                                             |
+|--------------------------|---------------------------------------------------------|
+| Lire une database        | Récupérer les propriétés et la structure d'une database |
+| Requêter une database    | Rechercher et filtrer des entrées dans une database     |
+| Créer une entrée         | Ajouter une nouvelle ligne dans une database            |
+| Mettre à jour une entrée | Modifier une entrée existante                           |
+
+### Opérations sur les blocs
+
+| Opération              | Description                                      |
+|------------------------|--------------------------------------------------|
+| Lire les blocs enfants | Récupérer les blocs de contenu d'une page        |
+| Ajouter des blocs      | Insérer du nouveau contenu (texte, images, etc.) |
+| Mettre à jour un bloc  | Modifier un bloc existant                        |
+| Supprimer un bloc      | Supprimer un bloc                                |
+
+### Opérations sur les utilisateurs
+
+| Opération               | Description                                    |
+|-------------------------|------------------------------------------------|
+| Lire un utilisateur     | Récupérer les infos d'un utilisateur           |
+| Lister les utilisateurs | Obtenir la liste des utilisateurs du workspace |
+
+---
+
+## Spécificités de l'API Notion
+
+### Version de l'API
+
+Notion utilise un système de versioning par date. Ajoutez toujours le header suivant dans vos requêtes :
+
+```
+Notion-Version: 2022-06-28
+```
+
+### Format d'authentification
+
+L'authentification OAuth de Notion utilise :
+- **Basic Auth** pour l'échange du code (format `clientId:clientSecret` en base64)
+- **Bearer Token** pour les requêtes API (`Authorization: Bearer <access_token>`)
+
+### Tokens qui n'expirent pas
+
+**Particularité importante** : Les access tokens Notion n'expirent jamais et il n'y a pas de refresh token. Une fois obtenu, le token reste valide jusqu'à ce que :
+- L'utilisateur révoque l'accès manuellement
+- L'intégration soit supprimée
+- L'intégration soit retirée du workspace
+
+### Partage des pages
+
+Pour qu'une intégration puisse accéder à une page ou database Notion, **l'utilisateur doit explicitement partager la page avec l'intégration**. Cela se fait via :
+1. Le menu "..." en haut à droite d'une page
+2. "Add connections"
+3. Sélectionner votre intégration
+
+Sans ce partage, l'API retournera une erreur 404 même si le token est valide.
+
+---
+
+## Test de l'intégration
+
+### 1. Démarrer le backend
+
+```bash
+cd backend
+npm run start:dev
+```
+
+### 2. Tester la connexion
+
+**Via l'interface frontend** :
+1. Accédez à la page de connexion
+2. Cliquez sur "Connect with Notion"
+3. Autorisez l'accès dans Notion
+4. Vous serez redirigé vers votre application
+
+**Via API directe** :
+```bash
+# 1. Obtenir l'URL de consentement
+curl http://localhost:3000/auth/notion/link?userId=your-user-id
+
+# 2. Ouvrir l'URL dans un navigateur et autoriser
+# 3. Le callback sera traité automatiquement
+```
+
+### 3. Vérifier le lien
+
+**Via l'API** :
+```bash
+# Vérifier que le compte est bien lié
+curl -H "Authorization: Bearer <your-jwt>" \
+  http://localhost:3000/auth/linked-accounts
+```
+
+**Dans la base de données** :
+```sql
+SELECT * FROM linked_accounts WHERE provider = 'notion' AND user_id = 'your-user-id';
+```
+
+### 4. Tester une requête API Notion
+
+Une fois lié, testez une requête simple :
+
+```typescript
+// Exemple : Lister les pages accessibles
+const accessToken = await notionLinking.getCurrentAccessToken(userId);
+
+const response = await fetch('https://api.notion.com/v1/search', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${accessToken}`,
+    'Notion-Version': '2022-06-28',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    filter: { property: 'object', value: 'page' }
+  })
+});
+
+const data = await response.json();
+console.log('Pages accessibles:', data.results);
+```
+
+---
+
+## Débogage
+
+### Erreur : "Invalid client_id or redirect_uri"
+
+**Cause** : Le client ID ou le redirect URI ne correspond pas à la configuration de votre intégration.
+
+**Solution** :
+1. Vérifiez que `NOTION_CLIENT_ID` correspond bien au OAuth client ID de votre intégration
+2. Vérifiez que `NOTION_REDIRECT_URI` est exactement le même que celui configuré dans "Distribution" > "Redirect URIs"
+3. Attention aux trailing slashes et au protocole (http vs https)
+
+### Erreur : "Unauthorized" ou 401
+
+**Cause** : Le token n'est pas valide ou a été révoqué.
+
+**Solution** :
+1. Vérifiez que le token est bien stocké et chiffré correctement
+2. Demandez à l'utilisateur de se reconnecter
+3. Vérifiez que l'intégration n'a pas été retirée du workspace
+
+### Erreur : "Object not found" ou 404
+
+**Causes possibles** :
+1. La page/database n'existe pas
+2. **L'intégration n'a pas accès à cette page** (cause la plus fréquente)
+
+**Solution** :
+1. Vérifiez que la page est bien partagée avec votre intégration
+2. Dans Notion, ouvrez la page → "..." → "Add connections" → Sélectionnez votre intégration
+3. Testez avec une page de test que vous avez explicitement partagée
+
+### Le token ne fonctionne plus
+
+**Cause** : L'utilisateur a révoqué l'accès ou l'intégration a été retirée.
+
+**Solution** :
+1. Vérifiez dans [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
+2. Demandez à l'utilisateur de se reconnecter
+3. Implémentez une gestion d'erreur qui détecte les 401 et demande une reconnexion
+
+---
+
+## Ressources officielles
+
+- 📖 [Documentation officielle Notion API](https://developers.notion.com/)
+- 🔐 [Guide OAuth Notion](https://developers.notion.com/docs/authorization)
+- 🎯 [Référence API complète](https://developers.notion.com/reference/intro)
+- 💬 [Forum développeurs Notion](https://community.notion.so/)
+- 🛠️ [SDK JavaScript officiel](https://github.com/makenotion/notion-sdk-js)
+
+---
+
+## Notes pour les développeurs
+
+### Différences avec d'autres OAuth providers
+
+1. **Pas de scopes** : Les permissions sont définies au niveau de l'intégration, pas dans l'URL OAuth
+2. **Basic Auth** : L'échange de code utilise Basic Auth au lieu de form-urlencoded
+3. **Tokens permanents** : Pas d'expiration, pas de refresh token
+4. **Partage explicite** : Les utilisateurs doivent manuellement partager chaque page avec l'intégration
+5. **API versionnée par date** : Toujours inclure le header `Notion-Version`
+
+### Bonnes pratiques
+
+1. **Gestion d'erreurs robuste** : Toujours vérifier les 401/404 et guider l'utilisateur
+2. **Rate limiting** : Notion limite à 3 requêtes par seconde (respectez les headers `Retry-After`)
+3. **Pagination** : Utilisez le paramètre `start_cursor` pour les listes longues
+4. **Cache** : Les tokens ne changeant jamais, vous pouvez les cacher longtemps
+5. **Validation** : Testez régulièrement que les tokens fonctionnent encore
+
+### Sécurité
+
+- ✅ Les tokens sont chiffrés avant d'être stockés en base de données
+- ✅ Le state JWT expire après 10 minutes pour éviter les attaques CSRF
+- ✅ Utilisez toujours HTTPS en production
+- ✅ Ne loggez jamais les access tokens en clair
+- ✅ Implémentez un système de révocation des tokens si nécessaire
+

--- a/backend/src/modules/auth/plugins/notion/notion-linking.ts
+++ b/backend/src/modules/auth/plugins/notion/notion-linking.ts
@@ -1,0 +1,152 @@
+import { Injectable, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { LinkingProvider } from '../../../../common/interfaces/oauth2.type';
+import type { TokenStore, TokenCrypto } from 'src/common/interfaces/crypto.type';
+import { OAuth2Client } from '../../core/oauth2-client';
+
+/**
+ * Notion linking plugin for connecting a Notion workspace to an existing user.
+ * Builds consent URL, handles callback to persist encrypted tokens, and
+ * supports token refresh and access token retrieval.
+ */
+@Injectable()
+export class NotionLinking implements LinkingProvider {
+  readonly key = 'notion' as const;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly jwt: JwtService,
+    private readonly store: TokenStore,
+    private readonly crypto: TokenCrypto,
+    private readonly http: OAuth2Client,
+  ) {}
+
+  /**
+   * Build the Notion consent URL for linking a Notion workspace to a user.
+   * This will redirect the user to Notion to authorize the integration.
+   * @param params.userId - Target application user id (signed into state)
+   * @param params.scopes - Optional list of scopes (Notion doesn't use traditional scopes)
+   * @param params.mobile - Optional flag to indicate mobile app flow
+   */
+  buildLinkUrl(params: { userId: string; scopes?: string[]; mobile?: boolean }): string {
+    const clientId = this.config.get<string>('NOTION_CLIENT_ID');
+    const redirectUri = this.config.get<string>('NOTION_REDIRECT_URI');
+    if (!clientId || !redirectUri) {
+      throw new InternalServerErrorException('Notion OAuth not configured');
+    }
+    if (!params.userId) throw new BadRequestException('userId is required for linking');
+
+    const state = this.jwt.sign(
+      { provider: 'notion', mode: 'link', userId: params.userId, mobile: params.mobile },
+      { expiresIn: '10m' }
+    );
+
+    const q = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      owner: 'user',
+      state,
+    });
+
+    return `https://api.notion.com/v1/oauth/authorize?${q.toString()}`;
+  }
+
+  /**
+   * Handle the OAuth linking callback and store encrypted access token.
+   * Notion OAuth tokens don't expire, so no refresh token is needed.
+   * @param code - Authorization code returned by Notion
+   * @param state - Signed state containing user id
+   * @returns The linked user id
+   */
+  async handleLinkCallback(code: string, state?: string): Promise<{ userId: string }> {
+    if (!code) throw new BadRequestException('Missing code');
+
+    const clientId = this.config.get<string>('NOTION_CLIENT_ID');
+    const clientSecret = this.config.get<string>('NOTION_CLIENT_SECRET');
+    const redirectUri = this.config.get<string>('NOTION_REDIRECT_URI');
+    if (!clientId || !clientSecret || !redirectUri) {
+      throw new InternalServerErrorException('Notion OAuth not configured');
+    }
+
+    const decoded = state ? (this.jwt.verify(state) as any) : null;
+    const userId = decoded?.userId as string | undefined;
+    if (!userId) throw new BadRequestException('Invalid state: userId missing');
+
+    // Exchange code for access token
+    // Notion uses Basic Auth with client_id:client_secret encoded in base64
+    // and expects JSON body, not form-urlencoded
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    
+    const tokenResponse = await fetch('https://api.notion.com/v1/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${basicAuth}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text().catch(() => '');
+      throw new BadRequestException(`Notion token exchange failed: ${errorText}`);
+    }
+
+    const tokenRes = await tokenResponse.json();
+
+    const accessToken = tokenRes.access_token as string | undefined;
+    const workspaceId = tokenRes.workspace_id as string | undefined;
+    const botId = tokenRes.bot_id as string | undefined;
+    
+    if (!accessToken) throw new BadRequestException('Notion token exchange failed');
+
+    // Use workspace_id as providerUserId, or bot_id if workspace_id is not available
+    const providerUserId = workspaceId || botId || 'notion-workspace';
+
+    // Notion tokens don't expire, so we set a far future date
+    await this.store.linkExternalAccount({
+      userId,
+      provider: 'notion',
+      providerUserId,
+      accessToken: this.crypto.encrypt(accessToken),
+      refreshToken: null, // Notion doesn't provide refresh tokens
+      accessTokenExpiresAt: new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000), // 100 years
+    });
+
+    return { userId };
+  }
+
+  /**
+   * Refresh the Notion access token.
+   * Note: Notion access tokens don't expire, so this method just returns the existing token.
+   * @param userId - Application user id
+   * @returns Current access token with a long expiry
+   */
+  async refreshAccessToken(userId: string): Promise<{ accessToken: string; expiresIn: number }> {
+    const account = await this.store.getLinkedAccount(userId, 'notion');
+    if (!account || !account.access_token) {
+      throw new BadRequestException('No Notion access token stored');
+    }
+
+    const accessToken = this.crypto.decrypt(account.access_token);
+    // Return a very long expiry since Notion tokens don't expire
+    return { accessToken, expiresIn: 100 * 365 * 24 * 60 * 60 }; // 100 years in seconds
+  }
+
+  /**
+   * Retrieve and decrypt the current Notion access token for the user.
+   */
+  async getCurrentAccessToken(userId: string): Promise<string> {
+    const account = await this.store.getLinkedAccount(userId, 'notion');
+    if (!account || !account.access_token) {
+      throw new BadRequestException('No Notion access token stored');
+    }
+    return this.crypto.decrypt(account.access_token);
+  }
+}
+

--- a/backend/test/auth/notion.linking.spec.ts
+++ b/backend/test/auth/notion.linking.spec.ts
@@ -1,0 +1,203 @@
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { NotionLinking } from '../../src/modules/auth/plugins/notion/notion-linking';
+import type { TokenCrypto, TokenStore } from 'src/common/interfaces/crypto.type';
+import { OAuth2Client } from '../../src/modules/auth/core/oauth2-client';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+describe('NotionLinking', () => {
+  let notionLinking: NotionLinking;
+  const cfg = {
+    get: jest.fn((k: string) => {
+      const map: Record<string, string> = {
+        NOTION_CLIENT_ID: 'test-notion-client-id',
+        NOTION_CLIENT_SECRET: 'test-notion-client-secret',
+        NOTION_REDIRECT_URI: 'http://localhost:3000/auth/notion/callback',
+      };
+      return map[k];
+    }),
+  } as unknown as ConfigService;
+  const jwt = {
+    sign: jest.fn(() => 'test-state-token'),
+    verify: jest.fn(() => ({ provider: 'notion', mode: 'link', userId: 'test-user-id' })),
+  } as any as JwtService;
+  const store: jest.Mocked<TokenStore> = {
+    getLinkedAccount: jest.fn(),
+    updateLinkedTokens: jest.fn(),
+    upsertIdentityForLogin: jest.fn(),
+    findById: jest.fn(),
+    linkExternalAccount: jest.fn().mockResolvedValue({ id: 'test-user-id', email: 'test@example.com' }),
+  } as any;
+  const crypto: jest.Mocked<TokenCrypto> = {
+    encrypt: jest.fn((s: string) => `encrypted-${s}`),
+    decrypt: jest.fn((s: string) => s.replace(/^encrypted-/, '')),
+  };
+  const http: jest.Mocked<OAuth2Client> = {
+    request: jest.fn(),
+    postForm: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    notionLinking = new NotionLinking(cfg, jwt as any, store as any, crypto as any, http as any);
+  });
+
+  describe('buildLinkUrl', () => {
+    beforeEach(() => {
+      // Reset cfg.get to return proper values for buildLinkUrl tests
+      (cfg.get as jest.Mock).mockImplementation((k: string) => {
+        const map: Record<string, string> = {
+          NOTION_CLIENT_ID: 'test-notion-client-id',
+          NOTION_CLIENT_SECRET: 'test-notion-client-secret',
+          NOTION_REDIRECT_URI: 'http://localhost:3000/auth/notion/callback',
+        };
+        return map[k];
+      });
+    });
+
+    it('should build a valid Notion OAuth URL', () => {
+      const url = notionLinking.buildLinkUrl({ userId: 'test-user-id' });
+
+      expect(url).toContain('https://api.notion.com/v1/oauth/authorize');
+      expect(url).toContain('client_id=test-notion-client-id');
+      expect(url).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fnotion%2Fcallback');
+      expect(url).toContain('response_type=code');
+      expect(url).toContain('owner=user');
+      expect(url).toContain('state=test-state-token');
+      expect(jwt.sign).toHaveBeenCalledWith(
+        { provider: 'notion', mode: 'link', userId: 'test-user-id', mobile: undefined },
+        { expiresIn: '10m' }
+      );
+    });
+
+    it('should include mobile flag in state when mobile is true', () => {
+      notionLinking.buildLinkUrl({ userId: 'test-user-id', mobile: true });
+
+      expect(jwt.sign).toHaveBeenCalledWith(
+        { provider: 'notion', mode: 'link', userId: 'test-user-id', mobile: true },
+        { expiresIn: '10m' }
+      );
+    });
+
+    it('should throw error when Notion OAuth is not configured', () => {
+      const originalGet = cfg.get;
+      jest.spyOn(cfg, 'get').mockReturnValue(undefined);
+
+      expect(() => notionLinking.buildLinkUrl({ userId: 'test-user-id' }))
+        .toThrow('Notion OAuth not configured');
+      
+      cfg.get = originalGet;
+    });
+
+    it('should throw error when userId is missing', () => {
+      expect(() => notionLinking.buildLinkUrl({ userId: '' }))
+        .toThrow('userId is required for linking');
+    });
+  });
+
+  describe('handleLinkCallback', () => {
+    beforeEach(() => {
+      // Reset cfg.get to return proper values for handleLinkCallback tests
+      (cfg.get as jest.Mock).mockImplementation((k: string) => {
+        const map: Record<string, string> = {
+          NOTION_CLIENT_ID: 'test-notion-client-id',
+          NOTION_CLIENT_SECRET: 'test-notion-client-secret',
+          NOTION_REDIRECT_URI: 'http://localhost:3000/auth/notion/callback',
+        };
+        return map[k];
+      });
+    });
+
+    it('should handle callback and store encrypted tokens', async () => {
+      const mockTokenResponse = {
+        access_token: 'notion-access-token',
+        workspace_id: 'notion-workspace-123',
+        bot_id: 'notion-bot-456',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTokenResponse,
+      });
+
+      const result = await notionLinking.handleLinkCallback('test-code', 'test-state');
+
+      expect(result).toEqual({ userId: 'test-user-id' });
+      expect(jwt.verify).toHaveBeenCalledWith('test-state');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.notion.com/v1/oauth/token',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Authorization': expect.stringContaining('Basic '),
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({
+            grant_type: 'authorization_code',
+            code: 'test-code',
+            redirect_uri: 'http://localhost:3000/auth/notion/callback',
+          }),
+        })
+      );
+      expect(store.linkExternalAccount).toHaveBeenCalledWith({
+        userId: 'test-user-id',
+        provider: 'notion',
+        providerUserId: 'notion-workspace-123',
+        accessToken: 'encrypted-notion-access-token',
+        refreshToken: null,
+        accessTokenExpiresAt: expect.any(Date),
+      });
+    });
+
+    it('should throw error when code is missing', async () => {
+      await expect(notionLinking.handleLinkCallback('', 'test-state'))
+        .rejects.toThrow('Missing code');
+    });
+
+    it('should throw error when state is invalid', async () => {
+      (jwt.verify as any).mockReturnValueOnce({});
+
+      await expect(notionLinking.handleLinkCallback('test-code', 'invalid-state'))
+        .rejects.toThrow('Invalid state: userId missing');
+    });
+  });
+
+  describe('getCurrentAccessToken', () => {
+    it('should return decrypted access token', async () => {
+      store.getLinkedAccount.mockResolvedValue({
+        access_token: 'encrypted-notion-token',
+      } as any);
+
+      const token = await notionLinking.getCurrentAccessToken('test-user-id');
+
+      expect(token).toBe('notion-token');
+      expect(store.getLinkedAccount).toHaveBeenCalledWith('test-user-id', 'notion');
+      expect(crypto.decrypt).toHaveBeenCalledWith('encrypted-notion-token');
+    });
+
+    it('should throw error when no token is stored', async () => {
+      store.getLinkedAccount.mockResolvedValue(null);
+
+      await expect(notionLinking.getCurrentAccessToken('test-user-id'))
+        .rejects.toThrow('No Notion access token stored');
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('should return existing token since Notion tokens dont expire', async () => {
+      store.getLinkedAccount.mockResolvedValue({
+        access_token: 'encrypted-notion-token',
+      } as any);
+
+      const result = await notionLinking.refreshAccessToken('test-user-id');
+
+      expect(result.accessToken).toBe('notion-token');
+      expect(result.expiresIn).toBe(100 * 365 * 24 * 60 * 60);
+    });
+  });
+});
+


### PR DESCRIPTION
## Description
This pull request introduces support for Notion OAuth in the authentication service. Key changes include:

- Added a `NotionLinking` provider to handle workspace linking, token management, and retrieval.
- Provided comprehensive documentation (`README.md`) to guide developers through the setup and configuration of Notion OAuth integration. Includes setup for environment variables, redirect URI configuration, and debugging tips.

These updates aim to simplify Notion integration for developers and improve onboarding efficiency.

## Type of Change
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Other (please specify)

## Testing
List the tests performed to verify your changes. Include instructions to reproduce if needed.

- [x] Unit tests
- [ ] Manual tests
- [ ] Integration tests (if applicable)
---