### PR TITLE
Spotify Pause Reaction

### DIFF
--- a/backend/src/common/interfaces/action-names.enum.ts
+++ b/backend/src/common/interfaces/action-names.enum.ts
@@ -18,6 +18,7 @@ export enum ReactionNamesEnum {
   LOG_EVENT = 'log_event',
   DISCORD_SEND_SERVER_MESSAGE = 'discord_send_server_message',
   SPOTIFY_LIKE_TRACK = 'spotify_like_track',
+  SPOTIFY_PAUSE_PLAYBACK = 'spotify_pause_playback',
 }
 
 /**

--- a/backend/src/common/interfaces/action-names.enum.ts
+++ b/backend/src/common/interfaces/action-names.enum.ts
@@ -17,6 +17,7 @@ export enum ReactionNamesEnum {
   SEND_EMAIL = 'send_email',
   LOG_EVENT = 'log_event',
   DISCORD_SEND_SERVER_MESSAGE = 'discord_send_server_message',
+  SPOTIFY_LIKE_TRACK = 'spotify_like_track',
 }
 
 /**

--- a/backend/src/modules/manager/manager.module.ts
+++ b/backend/src/modules/manager/manager.module.ts
@@ -12,6 +12,7 @@ import { GmailNewMailService } from '../actions/gmail/new-mail.service';
 import { NotionDatabaseItemService } from '../actions/notion/database-item.service';
 import { GmailSendService } from '../reactions/gmail/send.service';
 import { DiscordSendService } from '../reactions/discord/send.service';
+import { SpotifyLikeReactionService } from '../reactions/spotify/like.service';
 import { ActionPollingService } from './polling/action-polling.service';
 import { PlaceholderReplacementService } from '../../common/services/placeholder-replacement.service';
 
@@ -32,6 +33,7 @@ import { PlaceholderReplacementService } from '../../common/services/placeholder
     NotionDatabaseItemService,
     GmailSendService,
     DiscordSendService,
+    SpotifyLikeReactionService,
     ActionPollingService,
     PlaceholderReplacementService,
   ],

--- a/backend/src/modules/manager/manager.module.ts
+++ b/backend/src/modules/manager/manager.module.ts
@@ -13,6 +13,7 @@ import { NotionDatabaseItemService } from '../actions/notion/database-item.servi
 import { GmailSendService } from '../reactions/gmail/send.service';
 import { DiscordSendService } from '../reactions/discord/send.service';
 import { SpotifyLikeReactionService } from '../reactions/spotify/like.service';
+import { SpotifyPauseService } from '../reactions/spotify/pause.service';
 import { ActionPollingService } from './polling/action-polling.service';
 import { PlaceholderReplacementService } from '../../common/services/placeholder-replacement.service';
 
@@ -34,6 +35,7 @@ import { PlaceholderReplacementService } from '../../common/services/placeholder
     GmailSendService,
     DiscordSendService,
     SpotifyLikeReactionService,
+    SpotifyPauseService,
     ActionPollingService,
     PlaceholderReplacementService,
   ],

--- a/backend/src/modules/manager/manager.service.ts
+++ b/backend/src/modules/manager/manager.service.ts
@@ -7,6 +7,7 @@ import { RedisService } from '../redis/redis.service';
 import { GmailSendService } from '../reactions/gmail/send.service';
 import { DiscordSendService } from '../reactions/discord/send.service';
 import { SpotifyLikeReactionService } from '../reactions/spotify/like.service';
+import { SpotifyPauseService } from '../reactions/spotify/pause.service';
 import { GmailNewMailService } from '../actions/gmail/new-mail.service';
 import { NotionDatabaseItemService } from '../actions/notion/database-item.service';
 import { PlaceholderReplacementService } from '../../common/services/placeholder-replacement.service';
@@ -37,6 +38,7 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
         [ReactionNamesEnum.LOG_EVENT]: 'default',
         [ReactionNamesEnum.DISCORD_SEND_SERVER_MESSAGE]: 'discord',
         [ReactionNamesEnum.SPOTIFY_LIKE_TRACK]: 'spotify',
+        [ReactionNamesEnum.SPOTIFY_PAUSE_PLAYBACK]: 'spotify',
     };
 
     constructor(
@@ -48,6 +50,7 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
         private readonly gmailSendService: GmailSendService,
         private readonly discordSendService: DiscordSendService,
         private readonly spotifyLikeReactionService: SpotifyLikeReactionService,
+        private readonly spotifyPauseService: SpotifyPauseService,
         private readonly gmailNewMailService: GmailNewMailService,
         private readonly notionDatabaseItemService: NotionDatabaseItemService,
         private readonly placeholderService: PlaceholderReplacementService,
@@ -68,6 +71,7 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
         [ReactionNamesEnum.LOG_EVENT]: 'Log to Console',
         [ReactionNamesEnum.DISCORD_SEND_SERVER_MESSAGE]: 'Send Discord Message',
         [ReactionNamesEnum.SPOTIFY_LIKE_TRACK]: 'Like Spotify Track',
+        [ReactionNamesEnum.SPOTIFY_PAUSE_PLAYBACK]: 'Pause Spotify Playback',
     };
 
     /**
@@ -258,6 +262,16 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
                     placeholder: '3n3Ppam7vgaVa1iaRUc9Lp'
                 }
             ]
+        });
+
+        // Spotify pause playback reaction
+        this.reactionCallbacks.set(ReactionNamesEnum.SPOTIFY_PAUSE_PLAYBACK, {
+            name: ReactionNamesEnum.SPOTIFY_PAUSE_PLAYBACK,
+            callback: async (userId: string, actionResult: any, config?: any) => {
+                return await this.spotifyPauseService.run(userId, config);
+            },
+            description: 'Pause the current Spotify playback',
+            configSchema: [] // No configuration needed
         });
 
         this.logger.log(`Registered ${this.reactionCallbacks.size} reaction callbacks`);

--- a/backend/src/modules/manager/manager.service.ts
+++ b/backend/src/modules/manager/manager.service.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { RedisService } from '../redis/redis.service';
 import { GmailSendService } from '../reactions/gmail/send.service';
 import { DiscordSendService } from '../reactions/discord/send.service';
+import { SpotifyLikeReactionService } from '../reactions/spotify/like.service';
 import { GmailNewMailService } from '../actions/gmail/new-mail.service';
 import { NotionDatabaseItemService } from '../actions/notion/database-item.service';
 import { PlaceholderReplacementService } from '../../common/services/placeholder-replacement.service';
@@ -35,6 +36,7 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
         [ReactionNamesEnum.SEND_EMAIL]: 'google',
         [ReactionNamesEnum.LOG_EVENT]: 'default',
         [ReactionNamesEnum.DISCORD_SEND_SERVER_MESSAGE]: 'discord',
+        [ReactionNamesEnum.SPOTIFY_LIKE_TRACK]: 'spotify',
     };
 
     constructor(
@@ -45,6 +47,7 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
         private readonly polling: ActionPollingService,
         private readonly gmailSendService: GmailSendService,
         private readonly discordSendService: DiscordSendService,
+        private readonly spotifyLikeReactionService: SpotifyLikeReactionService,
         private readonly gmailNewMailService: GmailNewMailService,
         private readonly notionDatabaseItemService: NotionDatabaseItemService,
         private readonly placeholderService: PlaceholderReplacementService,
@@ -64,6 +67,7 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
         [ReactionNamesEnum.SEND_EMAIL]: 'Send Email',
         [ReactionNamesEnum.LOG_EVENT]: 'Log to Console',
         [ReactionNamesEnum.DISCORD_SEND_SERVER_MESSAGE]: 'Send Discord Message',
+        [ReactionNamesEnum.SPOTIFY_LIKE_TRACK]: 'Like Spotify Track',
     };
 
     /**
@@ -234,6 +238,24 @@ export class ManagerService implements OnModuleInit, OnModuleDestroy {
                     required: true,
                     label: 'Message content',
                     placeholder: 'Hello, this is a test message!'
+                }
+            ]
+        });
+
+        // Spotify like track reaction
+        this.reactionCallbacks.set(ReactionNamesEnum.SPOTIFY_LIKE_TRACK, {
+            name: ReactionNamesEnum.SPOTIFY_LIKE_TRACK,
+            callback: async (userId: string, actionResult: any, config: { trackId: string }) => {
+                return await this.spotifyLikeReactionService.run(userId, config);
+            },
+            description: 'Like (save) a track to your Spotify library',
+            configSchema: [
+                {
+                    name: 'trackId',
+                    type: 'string',
+                    required: true,
+                    label: 'Spotify Track ID',
+                    placeholder: '3n3Ppam7vgaVa1iaRUc9Lp'
                 }
             ]
         });

--- a/backend/src/modules/reactions/spotify/like.service.ts
+++ b/backend/src/modules/reactions/spotify/like.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UsersService } from '../../users/users.service';
+import { ProviderKeyEnum } from '../../../common/interfaces/oauth2.type';
+import { AuthService } from '../../auth/auth.service';
+import type { Reactions, Field } from '../../../common/interfaces/area.type';
+
+/**
+ * Spotify reaction that likes (saves) a track to the user's library.
+ *
+ * This service uses the Spotify API to add a track to the user's "Liked Songs".
+ */
+@Injectable()
+export class SpotifyLikeReactionService implements Reactions {
+    /** Logger instance scoped to this service. */
+    private readonly logger = new Logger(SpotifyLikeReactionService.name);
+
+    constructor(
+        /** Users domain service used to resolve linked provider accounts. */
+        private readonly usersService: UsersService,
+        /** Auth service used to perform OAuth2-authenticated requests to Spotify. */
+        private readonly authService: AuthService,
+    ) {}
+
+    /**
+     * Likes a track on Spotify using the Spotify API.
+     *
+     * @param userId - The user identifier.
+     * @param params - Object containing the track ID to like.
+     * @param params.trackId - Spotify track ID (e.g., "3n3Ppam7vgaVa1iaRUc9Lp").
+     * @returns A promise that resolves when the track is liked.
+     */
+    async run(userId: string, params: { trackId: string }): Promise<void> {
+        // Retrieve the user's linked Spotify account
+        const spotifyAccount = await this.usersService.findLinkedAccount(userId, ProviderKeyEnum.Spotify);
+        if (!spotifyAccount) {
+            this.logger.warn(`User ${userId} does not have a linked Spotify account.`);
+            throw new Error('Spotify account not linked');
+        }
+
+        // Validate and clean trackId format
+        // Remove query parameters and extract just the track ID
+        let trackId = params.trackId?.trim();
+        if (!trackId) {
+            this.logger.warn(`Invalid track ID provided for user ${userId}`);
+            throw new Error('Track ID is required');
+        }
+
+        // If it's a full Spotify URL, extract the track ID
+        if (trackId.includes('spotify.com/track/')) {
+            const match = trackId.match(/track\/([a-zA-Z0-9]+)/);
+            if (match) {
+                trackId = match[1];
+            }
+        }
+
+        // Remove any query parameters (e.g., ?si=...)
+        const queryIndex = trackId.indexOf('?');
+        if (queryIndex !== -1) {
+            trackId = trackId.substring(0, queryIndex);
+        }
+
+        // Validate it's a valid base62 Spotify ID (alphanumeric)
+        if (!/^[a-zA-Z0-9]+$/.test(trackId)) {
+            this.logger.warn(`Invalid track ID format for user ${userId}: ${trackId}`);
+            throw new Error('Invalid track ID format');
+        }
+
+        // Get access token using AuthService
+        const accessToken = await this.authService.getCurrentAccessToken(ProviderKeyEnum.Spotify, userId);
+        if (!accessToken) {
+            this.logger.warn(`Failed to obtain access token for user ${userId}.`);
+            throw new Error('Failed to obtain access token');
+        }
+
+        // Like the track using Spotify API
+        // PUT https://api.spotify.com/v1/me/tracks
+        const url = 'https://api.spotify.com/v1/me/tracks';
+        try {
+            await this.authService.oAuth2ApiRequest(ProviderKeyEnum.Spotify, userId, {
+                method: 'PUT',
+                url,
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json',
+                },
+                data: {
+                    ids: [trackId],
+                },
+            });
+            this.logger.log(`Successfully liked track ${trackId} for user ${userId}.`);
+        } catch (err: any) {
+            const status = err?.response?.status;
+            const data = err?.response?.data;
+            this.logger.error(
+                `Failed to like track ${trackId} for user ${userId}: status=${status} body=${JSON.stringify(data)}`,
+            );
+            throw new Error('Failed to like track on Spotify');
+        }
+    }
+
+    getFields(): Field[] {
+        const fields: Field[] = [
+            {
+                name: 'trackId',
+                type: 'string',
+                required: true,
+            },
+        ];
+        return fields;
+    }
+}

--- a/backend/src/modules/reactions/spotify/pause.service.ts
+++ b/backend/src/modules/reactions/spotify/pause.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UsersService } from '../../users/users.service';
+import { ProviderKeyEnum } from '../../../common/interfaces/oauth2.type';
+import { AuthService } from '../../auth/auth.service';
+import type { Reactions, Field } from '../../../common/interfaces/area.type';
+
+/**
+ * Spotify reaction that pauses the user's current playback.
+ *
+ * This service uses the Spotify API to pause whatever is currently playing.
+ */
+@Injectable()
+export class SpotifyPauseService implements Reactions {
+    /** Logger instance scoped to this service. */
+    private readonly logger = new Logger(SpotifyPauseService.name);
+
+    constructor(
+        /** Users domain service used to resolve linked provider accounts. */
+        private readonly usersService: UsersService,
+        /** Auth service used to perform OAuth2-authenticated requests to Spotify. */
+        private readonly authService: AuthService,
+    ) {}
+
+    /**
+     * Pauses the user's current Spotify playback.
+     *
+     * @param userId - The user identifier.
+     * @param params - Optional parameters (currently none required).
+     * @returns A promise that resolves when playback is paused.
+     */
+    async run(userId: string, params?: Record<string, any>): Promise<void> {
+        // Retrieve the user's linked Spotify account
+        const spotifyAccount = await this.usersService.findLinkedAccount(userId, ProviderKeyEnum.Spotify);
+        if (!spotifyAccount) {
+            this.logger.warn(`User ${userId} does not have a linked Spotify account.`);
+            throw new Error('Spotify account not linked');
+        }
+
+        // Get access token using AuthService
+        const accessToken = await this.authService.getCurrentAccessToken(ProviderKeyEnum.Spotify, userId);
+        if (!accessToken) {
+            this.logger.warn(`Failed to obtain access token for user ${userId}.`);
+            throw new Error('Failed to obtain access token');
+        }
+
+        // Pause playback using Spotify API
+        // PUT https://api.spotify.com/v1/me/player/pause
+        const url = 'https://api.spotify.com/v1/me/player/pause';
+        try {
+            await this.authService.oAuth2ApiRequest(ProviderKeyEnum.Spotify, userId, {
+                method: 'PUT',
+                url,
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+            });
+            this.logger.log(`Successfully paused playback for user ${userId}.`);
+        } catch (err: any) {
+            const status = err?.response?.status;
+            const data = err?.response?.data;
+            
+            // 404 means no active device, which is a common scenario
+            if (status === 404) {
+                this.logger.warn(`No active device found for user ${userId}`);
+                throw new Error('No active Spotify device found');
+            }
+            
+            this.logger.error(
+                `Failed to pause playback for user ${userId}: status=${status} body=${JSON.stringify(data)}`,
+            );
+            throw new Error('Failed to pause Spotify playback');
+        }
+    }
+
+    getFields(): Field[] {
+        // No configuration fields needed for pause
+        return [];
+    }
+}

--- a/backend/test/manager/manager.service.spec.ts
+++ b/backend/test/manager/manager.service.spec.ts
@@ -9,6 +9,7 @@ import { GmailNewMailService } from '../../src/modules/actions/gmail/new-mail.se
 import { NotionDatabaseItemService } from '../../src/modules/actions/notion/database-item.service';
 import { GmailSendService } from '../../src/modules/reactions/gmail/send.service';
 import { DiscordSendService } from '../../src/modules/reactions/discord/send.service';
+import { SpotifyLikeReactionService } from '../../src/modules/reactions/spotify/like.service';
 import { ActionPollingService } from '../../src/modules/manager/polling/action-polling.service';
 import { PlaceholderReplacementService } from '../../src/common/services/placeholder-replacement.service';
 import { ActionNamesEnum, ReactionNamesEnum } from '../../src/common/interfaces/action-names.enum';
@@ -90,6 +91,10 @@ describe('ManagerService', () => {
     run: jest.fn(),
   };
 
+  const mockSpotifyLikeReactionService = {
+    run: jest.fn(),
+  };
+
   const mockDiscordMessageService = {
     supports: jest.fn(),
     start: jest.fn(),
@@ -124,6 +129,7 @@ describe('ManagerService', () => {
         { provide: NotionDatabaseItemService, useValue: mockNotionDatabaseItemService },
         { provide: GmailSendService, useValue: mockGmailSendService },
         { provide: DiscordSendService, useValue: mockDiscordSendService },
+        { provide: SpotifyLikeReactionService, useValue: mockSpotifyLikeReactionService },
         { provide: ActionPollingService, useValue: mockActionPollingService },
         { provide: PlaceholderReplacementService, useValue: mockPlaceholderService },
       ],
@@ -383,6 +389,10 @@ describe('ManagerService', () => {
           name: ReactionNamesEnum.DISCORD_SEND_SERVER_MESSAGE,
           services: { name: 'discord' },
         },
+        {
+          name: ReactionNamesEnum.SPOTIFY_LIKE_TRACK,
+          services: { name: 'spotify' },
+        },
       ]);
 
       const result = await service.getAvailableReactionsGrouped(userId);
@@ -415,6 +425,16 @@ describe('ManagerService', () => {
               name: ReactionNamesEnum.SEND_EMAIL,
               displayName: 'Send Email',
               description: 'Send email notification',
+            },
+          ],
+        },
+        spotify: {
+          isLinked: false,
+          items: [
+            {
+              name: ReactionNamesEnum.SPOTIFY_LIKE_TRACK,
+              displayName: 'Like Spotify Track',
+              description: 'Like (save) a track to your Spotify library',
             },
           ],
         },

--- a/backend/test/manager/manager.service.spec.ts
+++ b/backend/test/manager/manager.service.spec.ts
@@ -10,6 +10,7 @@ import { NotionDatabaseItemService } from '../../src/modules/actions/notion/data
 import { GmailSendService } from '../../src/modules/reactions/gmail/send.service';
 import { DiscordSendService } from '../../src/modules/reactions/discord/send.service';
 import { SpotifyLikeReactionService } from '../../src/modules/reactions/spotify/like.service';
+import { SpotifyPauseService } from '../../src/modules/reactions/spotify/pause.service';
 import { ActionPollingService } from '../../src/modules/manager/polling/action-polling.service';
 import { PlaceholderReplacementService } from '../../src/common/services/placeholder-replacement.service';
 import { ActionNamesEnum, ReactionNamesEnum } from '../../src/common/interfaces/action-names.enum';
@@ -95,6 +96,10 @@ describe('ManagerService', () => {
     run: jest.fn(),
   };
 
+  const mockSpotifyPauseService = {
+    run: jest.fn(),
+  };
+
   const mockDiscordMessageService = {
     supports: jest.fn(),
     start: jest.fn(),
@@ -130,6 +135,7 @@ describe('ManagerService', () => {
         { provide: GmailSendService, useValue: mockGmailSendService },
         { provide: DiscordSendService, useValue: mockDiscordSendService },
         { provide: SpotifyLikeReactionService, useValue: mockSpotifyLikeReactionService },
+        { provide: SpotifyPauseService, useValue: mockSpotifyPauseService },
         { provide: ActionPollingService, useValue: mockActionPollingService },
         { provide: PlaceholderReplacementService, useValue: mockPlaceholderService },
       ],
@@ -393,6 +399,10 @@ describe('ManagerService', () => {
           name: ReactionNamesEnum.SPOTIFY_LIKE_TRACK,
           services: { name: 'spotify' },
         },
+        {
+          name: ReactionNamesEnum.SPOTIFY_PAUSE_PLAYBACK,
+          services: { name: 'spotify' },
+        },
       ]);
 
       const result = await service.getAvailableReactionsGrouped(userId);
@@ -435,6 +445,11 @@ describe('ManagerService', () => {
               name: ReactionNamesEnum.SPOTIFY_LIKE_TRACK,
               displayName: 'Like Spotify Track',
               description: 'Like (save) a track to your Spotify library',
+            },
+            {
+              name: ReactionNamesEnum.SPOTIFY_PAUSE_PLAYBACK,
+              displayName: 'Pause Spotify Playback',
+              description: 'Pause the current Spotify playback',
             },
           ],
         },

--- a/backend/test/reactions/spotify/like.service.spec.ts
+++ b/backend/test/reactions/spotify/like.service.spec.ts
@@ -1,0 +1,240 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SpotifyLikeReactionService } from '../../../src/modules/reactions/spotify/like.service';
+import { UsersService } from '../../../src/modules/users/users.service';
+import { AuthService } from '../../../src/modules/auth/auth.service';
+import { ProviderKeyEnum } from '../../../src/common/interfaces/oauth2.type';
+
+// Mock UsersService
+const mockUsersService = {
+    findLinkedAccount: jest.fn(),
+};
+
+// Mock AuthService
+const mockAuthService = {
+    getCurrentAccessToken: jest.fn(),
+    oAuth2ApiRequest: jest.fn(),
+};
+
+describe('SpotifyLikeReactionService', () => {
+    let service: SpotifyLikeReactionService;
+    let usersService: typeof mockUsersService;
+    let authService: typeof mockAuthService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SpotifyLikeReactionService,
+                { provide: UsersService, useValue: mockUsersService },
+                { provide: AuthService, useValue: mockAuthService },
+            ],
+        }).compile();
+
+        service = module.get<SpotifyLikeReactionService>(SpotifyLikeReactionService);
+        usersService = module.get(UsersService);
+        authService = module.get(AuthService);
+        jest.clearAllMocks();
+    });
+
+    describe('run', () => {
+        const userId = 'user-123';
+        const params = {
+            trackId: '3n3Ppam7vgaVa1iaRUc9Lp',
+        };
+
+        it('should like a track successfully when user has linked Spotify account and valid token', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockApiResponse = { data: {}, status: 200 };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockResolvedValue(mockApiResponse);
+
+            // Act
+            await service.run(userId, params);
+
+            // Assert
+            expect(usersService.findLinkedAccount).toHaveBeenCalledWith(userId, ProviderKeyEnum.Spotify);
+            expect(authService.getCurrentAccessToken).toHaveBeenCalledWith(ProviderKeyEnum.Spotify, userId);
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    method: 'PUT',
+                    url: 'https://api.spotify.com/v1/me/tracks',
+                    headers: {
+                        Authorization: `Bearer ${mockAccessToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                    data: {
+                        ids: [params.trackId],
+                    },
+                })
+            );
+        });
+
+        it('should throw error when user does not have linked Spotify account', async () => {
+            // Arrange
+            usersService.findLinkedAccount.mockResolvedValue(null);
+
+            // Act & Assert
+            await expect(service.run(userId, params)).rejects.toThrow('Spotify account not linked');
+            expect(usersService.findLinkedAccount).toHaveBeenCalledWith(userId, ProviderKeyEnum.Spotify);
+            expect(authService.getCurrentAccessToken).not.toHaveBeenCalled();
+            expect(authService.oAuth2ApiRequest).not.toHaveBeenCalled();
+        });
+
+        it('should throw error when access token cannot be obtained', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(null);
+
+            // Act & Assert
+            await expect(service.run(userId, params)).rejects.toThrow('Failed to obtain access token');
+            expect(usersService.findLinkedAccount).toHaveBeenCalledWith(userId, ProviderKeyEnum.Spotify);
+            expect(authService.getCurrentAccessToken).toHaveBeenCalledWith(ProviderKeyEnum.Spotify, userId);
+            expect(authService.oAuth2ApiRequest).not.toHaveBeenCalled();
+        });
+
+        it('should throw error when trackId is empty or missing', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+
+            // Act & Assert
+            await expect(service.run(userId, { trackId: '' })).rejects.toThrow('Track ID is required');
+            await expect(service.run(userId, { trackId: '   ' })).rejects.toThrow('Track ID is required');
+            expect(authService.oAuth2ApiRequest).not.toHaveBeenCalled();
+        });
+
+        it('should clean track ID by removing query parameters', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockApiResponse = { data: {}, status: 200 };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockResolvedValue(mockApiResponse);
+
+            // Act
+            await service.run(userId, { trackId: '20X3JnZ5J6eNGXpypFQNxa?si=3d3db895c1534063' });
+
+            // Assert
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    data: {
+                        ids: ['20X3JnZ5J6eNGXpypFQNxa'], // Query params removed
+                    },
+                })
+            );
+        });
+
+        it('should extract track ID from full Spotify URL', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockApiResponse = { data: {}, status: 200 };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockResolvedValue(mockApiResponse);
+
+            // Act
+            await service.run(userId, { trackId: 'https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp?si=abc123' });
+
+            // Assert
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    data: {
+                        ids: ['3n3Ppam7vgaVa1iaRUc9Lp'], // Extracted and cleaned
+                    },
+                })
+            );
+        });
+
+        it('should throw error for invalid track ID format', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+
+            // Act & Assert
+            await expect(service.run(userId, { trackId: 'invalid@track#id!' })).rejects.toThrow('Invalid track ID format');
+            expect(authService.oAuth2ApiRequest).not.toHaveBeenCalled();
+        });
+
+        it('should throw error when Spotify API request fails', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockError = {
+                response: {
+                    status: 404,
+                    data: { error: { message: 'Track not found' } },
+                },
+            };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockRejectedValue(mockError);
+
+            // Act & Assert
+            await expect(service.run(userId, params)).rejects.toThrow('Failed to like track on Spotify');
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    method: 'PUT',
+                    url: 'https://api.spotify.com/v1/me/tracks',
+                })
+            );
+        });
+
+        it('should handle multiple track IDs by liking the provided track', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockApiResponse = { data: {}, status: 200 };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockResolvedValue(mockApiResponse);
+
+            // Act
+            await service.run(userId, { trackId: '7ouMYWpwJ422jRcDASZB7P' });
+
+            // Assert
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    data: {
+                        ids: ['7ouMYWpwJ422jRcDASZB7P'],
+                    },
+                })
+            );
+        });
+    });
+
+    describe('getFields', () => {
+        it('should return correct field schema', () => {
+            // Act
+            const fields = service.getFields();
+
+            // Assert
+            expect(fields).toEqual([
+                {
+                    name: 'trackId',
+                    type: 'string',
+                    required: true,
+                },
+            ]);
+        });
+    });
+});

--- a/backend/test/reactions/spotify/pause.service.spec.ts
+++ b/backend/test/reactions/spotify/pause.service.spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SpotifyPauseService } from '../../../src/modules/reactions/spotify/pause.service';
+import { UsersService } from '../../../src/modules/users/users.service';
+import { AuthService } from '../../../src/modules/auth/auth.service';
+import { ProviderKeyEnum } from '../../../src/common/interfaces/oauth2.type';
+
+// Mock UsersService
+const mockUsersService = {
+    findLinkedAccount: jest.fn(),
+};
+
+// Mock AuthService
+const mockAuthService = {
+    getCurrentAccessToken: jest.fn(),
+    oAuth2ApiRequest: jest.fn(),
+};
+
+describe('SpotifyPauseService', () => {
+    let service: SpotifyPauseService;
+    let usersService: typeof mockUsersService;
+    let authService: typeof mockAuthService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SpotifyPauseService,
+                { provide: UsersService, useValue: mockUsersService },
+                { provide: AuthService, useValue: mockAuthService },
+            ],
+        }).compile();
+
+        service = module.get<SpotifyPauseService>(SpotifyPauseService);
+        usersService = module.get(UsersService);
+        authService = module.get(AuthService);
+        jest.clearAllMocks();
+    });
+
+    describe('run', () => {
+        const userId = 'user-123';
+
+        it('should pause playback successfully when user has linked Spotify account and valid token', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockApiResponse = { data: {}, status: 204 };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockResolvedValue(mockApiResponse);
+
+            // Act
+            await service.run(userId);
+
+            // Assert
+            expect(usersService.findLinkedAccount).toHaveBeenCalledWith(userId, ProviderKeyEnum.Spotify);
+            expect(authService.getCurrentAccessToken).toHaveBeenCalledWith(ProviderKeyEnum.Spotify, userId);
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    method: 'PUT',
+                    url: 'https://api.spotify.com/v1/me/player/pause',
+                    headers: {
+                        Authorization: `Bearer ${mockAccessToken}`,
+                    },
+                })
+            );
+        });
+
+        it('should pause playback with optional params', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockApiResponse = { data: {}, status: 204 };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockResolvedValue(mockApiResponse);
+
+            // Act
+            await service.run(userId, { someParam: 'value' });
+
+            // Assert
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalled();
+        });
+
+        it('should throw error when user does not have linked Spotify account', async () => {
+            // Arrange
+            usersService.findLinkedAccount.mockResolvedValue(null);
+
+            // Act & Assert
+            await expect(service.run(userId)).rejects.toThrow('Spotify account not linked');
+            expect(usersService.findLinkedAccount).toHaveBeenCalledWith(userId, ProviderKeyEnum.Spotify);
+            expect(authService.getCurrentAccessToken).not.toHaveBeenCalled();
+            expect(authService.oAuth2ApiRequest).not.toHaveBeenCalled();
+        });
+
+        it('should throw error when access token cannot be obtained', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(null);
+
+            // Act & Assert
+            await expect(service.run(userId)).rejects.toThrow('Failed to obtain access token');
+            expect(usersService.findLinkedAccount).toHaveBeenCalledWith(userId, ProviderKeyEnum.Spotify);
+            expect(authService.getCurrentAccessToken).toHaveBeenCalledWith(ProviderKeyEnum.Spotify, userId);
+            expect(authService.oAuth2ApiRequest).not.toHaveBeenCalled();
+        });
+
+        it('should throw specific error when no active device is found (404)', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockError = {
+                response: {
+                    status: 404,
+                    data: { error: { message: 'Device not found' } },
+                },
+            };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockRejectedValue(mockError);
+
+            // Act & Assert
+            await expect(service.run(userId)).rejects.toThrow('No active Spotify device found');
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    method: 'PUT',
+                    url: 'https://api.spotify.com/v1/me/player/pause',
+                })
+            );
+        });
+
+        it('should throw generic error when Spotify API request fails with other error', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const mockError = {
+                response: {
+                    status: 403,
+                    data: { error: { message: 'Forbidden' } },
+                },
+            };
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockRejectedValue(mockError);
+
+            // Act & Assert
+            await expect(service.run(userId)).rejects.toThrow('Failed to pause Spotify playback');
+            expect(authService.oAuth2ApiRequest).toHaveBeenCalledWith(
+                ProviderKeyEnum.Spotify,
+                userId,
+                expect.objectContaining({
+                    method: 'PUT',
+                    url: 'https://api.spotify.com/v1/me/player/pause',
+                })
+            );
+        });
+
+        it('should handle network errors gracefully', async () => {
+            // Arrange
+            const mockLinkedAccount = { id: 'linked-account-id', provider: 'spotify' };
+            const mockAccessToken = 'valid-spotify-access-token';
+            const networkError = new Error('Network error');
+
+            usersService.findLinkedAccount.mockResolvedValue(mockLinkedAccount);
+            authService.getCurrentAccessToken.mockResolvedValue(mockAccessToken);
+            authService.oAuth2ApiRequest.mockRejectedValue(networkError);
+
+            // Act & Assert
+            await expect(service.run(userId)).rejects.toThrow('Failed to pause Spotify playback');
+        });
+    });
+
+    describe('getFields', () => {
+        it('should return empty array as no configuration is needed', () => {
+            // Act
+            const fields = service.getFields();
+
+            // Assert
+            expect(fields).toEqual([]);
+            expect(fields).toHaveLength(0);
+        });
+    });
+});


### PR DESCRIPTION
## Description
This pull request adds two new Spotify reactions—liking a track and pausing playback—integrating them into the backend system alongside updates to dependency injection, service registration, and test coverage. These changes enable users to automate Spotify actions as part of their workflows, similar to existing reactions for Gmail and Discord.

**Spotify Reaction Integration:**

* Added new reaction types: `SPOTIFY_LIKE_TRACK` and `SPOTIFY_PAUSE_PLAYBACK` to `ReactionNamesEnum`, and registered them with appropriate display names and service mappings in `ManagerService`. [[1]](diffhunk://#diff-87f424641772bd3a9ba34dda9ba783a245a8969121a908d01e14c5bee8c838dcR20-R21) [[2]](diffhunk://#diff-ac9f5a0a8548bc22c63b65f74dfb2097b9112c39fb1e45f940b6f1370f2fb6a6R40-R41) [[3]](diffhunk://#diff-ac9f5a0a8548bc22c63b65f74dfb2097b9112c39fb1e45f940b6f1370f2fb6a6R73-R74)
* Implemented `SpotifyLikeReactionService` to allow users to like (save) a track to their Spotify library, with input validation and error handling for Spotify account linkage and track ID format.
* Implemented `SpotifyPauseService` to allow users to pause their current Spotify playback, handling the case where no active device is found.
* Registered both Spotify services in the DI container and made them available in the manager module. [[1]](diffhunk://#diff-5c05605c82305a28c2c6ae596230a7df1573e81bed5f56cd37f8354b19739ca3R15-R16) [[2]](diffhunk://#diff-5c05605c82305a28c2c6ae596230a7df1573e81bed5f56cd37f8354b19739ca3R37-R38) [[3]](diffhunk://#diff-ac9f5a0a8548bc22c63b65f74dfb2097b9112c39fb1e45f940b6f1370f2fb6a6R52-R53)

**Callback and Configuration:**

* Added reaction callbacks for both Spotify actions in `ManagerService`, with appropriate configuration schemas and error handling.

**Testing:**

* Updated tests to mock and verify the new Spotify reaction services, and ensured they appear in grouped reaction lists and available reactions data structures. [[1]](diffhunk://#diff-61e32c265338d8286c483e8c491f351c586ec6cffdd2dca394495771c66f8ddeR12) [[2]](diffhunk://#diff-61e32c265338d8286c483e8c491f351c586ec6cffdd2dca394495771c66f8ddeR94-R97) [[3]](diffhunk://#diff-61e32c265338d8286c483e8c491f351c586ec6cffdd2dca394495771c66f8ddeR132) [[4]](diffhunk://#diff-61e32c265338d8286c483e8c491f351c586ec6cffdd2dca394495771c66f8ddeR392-R395) [[5]](diffhunk://#diff-61e32c265338d8286c483e8c491f351c586ec6cffdd2dca394495771c66f8ddeR431-R440)

## Type of Change
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify)

## Testing
- [x] Unit tests
- [x] Manual tests
- [ ] Integration tests (if applicable)
---
Closes #156